### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ You can see the demo app for `SSCollectionViewExchangeController` in action [her
 `SSCollectionViewExchangeController` uses `UICollectionView` which was available starting with iOS 6.0.
 
 
-### Cocoapods
+### CocoaPods
 
 1. Add an entry to your Podfile: `pod 'SSCollectionViewExchangeController'`
 2. Install the pod(s) by running: `pod install`


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
